### PR TITLE
Fix initialRegion when using RN 0.54 (#2131)

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -199,7 +199,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 - (void)setInitialRegion:(MKCoordinateRegion)initialRegion {
   if (_initialRegionSetOnLoad) return;
   _initialRegion = initialRegion;
-  _initialRegionSetOnLoad = true;
+  _initialRegionSetOnLoad = _didMoveToWindow;
   self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:initialRegion];
 }
 


### PR DESCRIPTION
* Fix initialRegion being zoomed out as described in https://github.com/react-community/react-native-maps/issues/2100

* Start ignoring setInitialRegion calls once the map view is in the window rather than when the map is ready

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

(please answer here)

### What issue is this PR fixing?

(please link the issue here)

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

(please answer here)

<!--
Thanks for your contribution :)
-->
